### PR TITLE
Automated release using GH Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           git push          
       
       - name: Cut release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
         with:
           tag_name: v${{ env.THIS_VERSION }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+# Creates a new bugfix release whenever a push is made to master.
+
+name: release
+
+# Controls when the action will run. 
+on:
+  push:
+    branches:
+      - master
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - name: Calculate next version
+        run: |
+          git pull
+          export CURRENT_VERSION=$(cat version.txt)
+          export THIS_VERSION=$(echo $CURRENT_VERSION | awk -F. -v OFS=. '{$NF++;print}')
+          echo "THIS_VERSION=$THIS_VERSION" >> $GITHUB_ENV
+      
+      - name: Store next version
+        run: |          
+          echo ${{ env.THIS_VERSION }} > version.txt
+          
+          git config user.name "GitHub Actions"
+          git config user.email "actions@users.noreply.github.com"
+          git commit -am "Automated release - advance the release version."
+          git push          
+      
+      - name: Cut release
+        uses: elgohr/Github-Release-Action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          args: v${{ env.THIS_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
           git push          
       
       - name: Cut release
-        uses: elgohr/Github-Release-Action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          args: v${{ env.THIS_VERSION }} v${{ env.THIS_VERSION }}
+          tag_name: v${{ env.THIS_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:
-          args: v${{ env.THIS_VERSION }}
+          args: v${{ env.THIS_VERSION }} v${{ env.THIS_VERSION }}

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,10 @@ Full Iris test data.
 
 This repository includes artificially created data.
 
+Pushes to ``master`` branch (i.e. pull request merges) will trigger an
+automatic increment of iris-test-data's minor release version (via a GitHub
+Action).
+
 
 .. |copy|   unicode:: U+000A9 .. COPYRIGHT SIGN
 
@@ -12,13 +16,13 @@ Data found in this repository are licensed under the UK's Open Government Licenc
 
 Documentation, example and data license
 ---------------------------------------
- 
+
     |copy| British Crown copyright, 2021.
-    
-    You may use and re-use the information featured in this repository (not including logos) free of 
-    charge in any format or medium, under the terms of the 
-    `Open Government Licence <http://reference.data.gov.uk/id/open-government-licence>`_. 
+
+    You may use and re-use the information featured in this repository (not including logos) free of
+    charge in any format or medium, under the terms of the
+    `Open Government Licence <http://reference.data.gov.uk/id/open-government-licence>`_.
     We encourage users to establish hypertext links to this website.
-    
-    Any email enquiries regarding the use and re-use of this information resource should be 
+
+    Any email enquiries regarding the use and re-use of this information resource should be
     sent to: psi@nationalarchives.gsi.gov.uk.


### PR DESCRIPTION
SciTools/iris#4024 means that Iris now expects to reference a specific release of iris-test-data. This effectively means any change to iris-test-data should involve a release.

So here is a proposal for a GitHub Action that creates a new release every time a push is made to `master`.

---

_The below is no longer needed since d7a55e884940e110896e05582b3a144253ca9425._

~~### Help needed~~

~~For the Action to work, a `RELEASE_TOKEN` is needed. Someone with admin permissions for the repo will need to do this:~~

~~- Create an access token with `public_repo` scope:~~
  <img src="https://user-images.githubusercontent.com/40734014/111303015-f2da6400-864b-11eb-878d-d7a19aae8edb.png" width="400">
~~- Create a new repo secret called `RELEASE_TOKEN`, set the value to that of the above access token.~~
