### PR TITLE
png support for indexing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
       - name: install iris-grib
         run: |
           source $CONDA/bin/activate base
-          conda install -y -c conda-forge iris-grib
+          conda install -q -y -c conda-forge iris-grib
       - name: generate index
         working-directory: indexing
         run: |

--- a/indexing/INDEX_template.md
+++ b/indexing/INDEX_template.md
@@ -1,18 +1,21 @@
-{%  for prefix, data in content.items()%}
+{% for prefix, data in content.items() %}
 
 <details>
 
   <summary>{{ prefix }}</summary>
 
-  {% for filepath, link_path, cube_strs, warnings, exceptions in data %}
-  # [{{ filepath }}]({{ link_path }})
+  {% for filepath, link_path, items, is_png, warnings, exceptions in data|sort(attribute="path") %}
+  #### [{{ filepath }}]({{ link_path }})
 
-  {% for cube_str in cube_strs %}
+  {% if is_png %}
+  ![{{ link_path }}]({{ link_path }})
+  {% else %}
+  {% for item in items %}
   ```
-      {{ cube_str | indent(first=False) }}
+      {{ item | indent(first=False) }}
   ```
   {% endfor %}
-
+  {% endif %}
   {%if warnings %}
   ```
   {% for warning_str in warnings %}


### PR DESCRIPTION
This PR extends the test data indexing support for `png` images.

An example index rendered by this PR is [here](https://github.com/bjlittle/iris-test-data/blob/master/INDEX.md).

Reference #71

Closes #73